### PR TITLE
manual: HTML fixes

### DIFF
--- a/grass-gis-addons/r.extract.buildings/r.extract.buildings.html
+++ b/grass-gis-addons/r.extract.buildings/r.extract.buildings.html
@@ -1,27 +1,36 @@
 <h2>DESCRIPTION</h2>
 
-<em>r.extract.buildings</em> extracts buildings as vectors and calculates height statistics (minimum, maximum, average, standard deviation, median, percentile) and
-presumable number of stories using an nDOM-raster, NDVI-raster, and FNK-vector (Flaechennutzungskatalog). As certain area codes from the FNK are used, the class codes have to be consistent.
-The extraction can be based on an image segmentation using <a href="i.segment.html">i.segment</a>, which requires the <b>-s</b> flag to be activated.
-Note that this significantly extends the processing time.
-<p>
-  A generic NDVI threshold is used to separate buildings from trees. This threshold is defined by calculating the
-  n-th percentile (indicated by the <b>ndvi_perc</b> option) of NDVI values from all vegetated areas. Vegetated areas
-  are defined from the FNK-vector - therefore the class codes have to be consistent. Alternatively, the NDVI threshold can be defined as a fixed NDVI value (on a scale from 0-255).
-<p>
-  Only buildings with a defined minimum size and minimum height are extracted.
-  The average story height is assumed to be 3 meters.
+<em>r.extract.buildings</em> extracts buildings as vectors and
+calculates height statistics (minimum, maximum, average, standard
+deviation, median, percentile) and presumable number of stories using
+an nDOM-raster, NDVI-raster, and FNK-vector (Flaechennutzungskatalog).
+As certain area codes from the FNK are used, the class codes have to be
+consistent. The extraction can be based on an image segmentation using
+<a href="i.segment.html">i.segment</a>, which requires the <b>-s</b>
+flag to be activated. Note that this significantly extends the
+processing time.
 
-
+<p>
+A generic NDVI threshold is used to separate buildings from trees. This
+threshold is defined by calculating the n-th percentile (indicated by
+the <b>ndvi_perc</b> option) of NDVI values from all vegetated areas.
+Vegetated areas are defined from the FNK-vector - therefore the class
+codes have to be consistent. Alternatively, the NDVI threshold can be
+defined as a fixed NDVI value (on a scale from 0-255).
+<p>
+Only buildings with a defined minimum size and minimum height are
+extracted. The average story height is assumed to be 3 meters.
 
 <h2>EXAMPLES</h2>
 
 <h3>Extraction using default values and the 5th percentile as NDVI threshold</h3>
+
 <div class="code"><pre>
 r.extract.buildings ndom=ndom_raster ndvi_raster=ndvi_raster fnk_vector=FNK_Bottrop_2017 fnk_column=code_akt output=buildings_ndviperc5 ndvi_perc=5
 </pre></div>
 
 <h3>Extraction using a fixed NDVI threshold and a differing minimum size of buildings</h3>
+
 <div class="code"><pre>
 r.extract.buildings ndom=ndom_raster ndvi_raster=ndvi_raster fnk_vector=FNK_Bottrop_2017 fnk_column=code_akt output=buildings_ndvithresh148 ndvi_thresh=148 min_size=30
 </pre></div>
@@ -31,15 +40,9 @@ r.extract.buildings ndom=ndom_raster ndvi_raster=ndvi_raster fnk_vector=FNK_Bott
 <em>
 <a href="r.mapcalc.html">r.mapcalc</a>,
 <a href="i.segment.html">i.segment</a>,
-<a href="r.quantile">r.quantile</a>,
+<a href="r.quantile">r.quantile</a>
 </em>
 
 <h2>AUTHOR</h2>
 
-Guido Riembauer, mundialis, riembauer at mundialis.de
-
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Guido Riembauer, <a href="https://www.mundialis.de/">mundialis</a>, riembauer at mundialis.de

--- a/grass-gis-addons/r.extract.greenroofs/r.extract.greenroofs.html
+++ b/grass-gis-addons/r.extract.greenroofs/r.extract.greenroofs.html
@@ -1,32 +1,57 @@
 <h2>DESCRIPTION</h2>
 
-<em>r.extract.greenroofs</em> extracts green roofs from aerial photographs, an nDOM, a building vector layer and optionally an FNK (Flaechennutzungskatalog) and tree vector layer.
-The module generates two outputs: The buildings outlines that have vegetated roofs (<em>output_buildings</em>) with an added attribute column
-containing the percentage of vegetated roof area with respect to total roof area. The second output (<em>output_vegetation</em>) contains
-only the vegetation objects.
+<em>r.extract.greenroofs</em> extracts green roofs from aerial
+photographs, an nDOM, a building vector layer and optionally an FNK
+(Flaechennutzungskatalog) and tree vector layer. The module generates
+two outputs: The buildings outlines that have vegetated roofs
+(<em>output_buildings</em>) with an added attribute column containing
+the percentage of vegetated roof area with respect to total roof area.
+The second output (<em>output_vegetation</em>) contains only the
+vegetation objects.
+
 <p>
-The module works best when a tree vector layer is used as input via the <em>trees</em> parameter. If this is not given, <em>r.extract.greenroofs</em> tries
-to eliminate false alarms by overhanging trees via the nDOM difference to the remaining roof area.
+The module works best when a tree vector layer is used as input via the
+<em>trees</em> parameter. If this is not given,
+<em>r.extract.greenroofs</em> tries to eliminate false alarms by
+overhanging trees via the nDOM difference to the remaining roof area.
+
 <p>
-Internally, a normalized difference green-blue ratio is used to discriminate vegetated from non-vegetated areas (the NDVI is not sensitive enough for sparse roof vegetation).
-A threshold for the green-blue ratio can be defined by the <em>gb_thresh</em> parameter. Empirical testing showed good results for a value of around <em>gb_thresh=145</em> (on a scale from 0 to 255).
-The threshold can also be automatically estimated from green areas defined in the FNK. For this, the <em>fnk</em>, <em>fnk_column</em>, and <em>gb_perc</em> parameters must be given.
-The latter defines the percentile of pixels in vegetated areas to define as gleen-blue ratio threshold. Empirical testing yielded good results for <em>gb_perc=25</em> (=1st quartile).
+Internally, a normalized difference green-blue ratio is used to
+discriminate vegetated from non-vegetated areas (the NDVI is not
+sensitive enough for sparse roof vegetation). A threshold for the
+green-blue ratio can be defined by the <em>gb_thresh</em> parameter.
+Empirical testing showed good results for a value of around
+<em>gb_thresh=145</em> (on a scale from 0 to 255). The threshold can
+also be automatically estimated from green areas defined in the FNK.
+For this, the <em>fnk</em>, <em>fnk_column</em>, and <em>gb_perc</em>
+parameters must be given. The latter defines the percentile of pixels
+in vegetated areas to define as gleen-blue ratio threshold. Empirical
+testing yielded good results for <em>gb_perc=25</em> (=1st quartile).
+
 <p>
-Optionally, the analysis can be run object-based instead of pixel-based by using the <em>-s</em> flag. This typically improves the result, but takes up more processing time.
-If no appropriate <em>gb_thresh</em> value is known, it is recommended to run the module a few times without the <em>-s</em> flag and inspect the result to identify a proper threshold.
-The final run should then be performed with the <em>-s</em> flag.
+Optionally, the analysis can be run object-based instead of pixel-based
+by using the <em>-s</em> flag. This typically improves the result, but
+takes up more processing time. If no appropriate <em>gb_thresh</em>
+value is known, it is recommended to run the module a few times without
+the <em>-s</em> flag and inspect the result to identify a proper
+threshold. The final run should then be performed with the <em>-s</em>
+flag.
+
 <p>
-The <em>min_veg_size</em> and <em>min_veg_proportion</em> parameters can be used to eliminate vegetated roof areas by size or proportion of total roof area.
+The <em>min_veg_size</em> and <em>min_veg_proportion</em> parameters
+can be used to eliminate vegetated roof areas by size or proportion of
+total roof area.
 
 <h2>EXAMPLES</h2>
 
 <h3>Extract green roofs by a fixed threshold of 145, use object based detection</h3>
+
 <div class="code"><pre>
 r.extract.greenroofs ndom=ndom_raster ndvi=ndvi_raster red=dop_red green=dop_green blue=dop_blue gb_thresh=145 buildings=buildings_vector trees=trees_vector output_buildings=result_buildings output_vegetation=result_vegetation -s
 </pre></div>
 
 <h3>Extract green roofs by an estimated threshold from the FNK using the 25% percentile as threshold, use pixel based detection</h3>
+
 <div class="code"><pre>
 r.extract.greenroofs ndom=ndom_raster ndvi=ndvi_raster red=dop_red green=dop_green blue=dop_blue gb_perc=25 fnk=fnk_vector fnk_column=fnk_code buildings=buildings_vector trees=trees_vector output_buildings=result_buildings output_vegetation=result_vegetation
 </pre></div>
@@ -36,15 +61,11 @@ r.extract.greenroofs ndom=ndom_raster ndvi=ndvi_raster red=dop_red green=dop_gre
 <em>
 <a href="r.mapcalc.html">r.mapcalc</a>,
 <a href="i.segment.html">i.segment</a>,
-<a href="r.quantile">r.quantile</a>,
+<a href="r.quantile">r.quantile</a>
 </em>
 
 <h2>AUTHORS</h2>
-Julia Haas, mundialis, haas at mundialis.de
-Guido Riembauer, mundialis, riembauer at mundialis.de
 
-
-<!--
+Julia Haas, <a href="https://www.mundialis.de/">mundialis</a>, haas at mundialis.de
 <p>
-<i>Last changed: $Date$</i>
--->
+Guido Riembauer, <a href="https://www.mundialis.de/">mundialis</a>, riembauer at mundialis.de

--- a/grass-gis-addons/r.import.dgm_nrw/r.import.dgm_nrw.html
+++ b/grass-gis-addons/r.import.dgm_nrw/r.import.dgm_nrw.html
@@ -1,10 +1,11 @@
 <h2>DESCRIPTION</h2>
 
-<em>r.import.dgm_nrw</em> downloads and imports the NRW DGM 1m into the current
-mapset. Only the extent of the current region is downloaded and imported with a 1m resolution.
-Note that data is only available for NRW and will be imported on a best-effort basis:
-If the current region exceeds NRW, all available DGM data for the region is still imported, but GRASS
-will give a warning.
+<em>r.import.dgm_nrw</em> downloads and imports the NRW DGM 1m into the
+current mapset. Only the extent of the current region is downloaded and
+imported with a 1m resolution. Note that data is only available for NRW
+and will be imported on a best-effort basis: If the current region
+exceeds NRW, all available DGM data for the region is still imported,
+but GRASS will give a warning.
 
 <h2>EXAMPLE</h2>
 
@@ -15,10 +16,11 @@ r.import.dgm output=dgm_1m
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.in.xyz.html">r.in.xyz</a>,
+<a href="r.in.xyz.html">r.in.xyz</a>
 </em>
 
 <h2>REFERENCES</h2>
+
 <ul>
   <li><a href="https://www.opengeodata.nrw.de/produkte/geobasis/hm/dgm1_xyz/dgm1_xyz/">download source</a></li>
   <li><a href="https://www.bezreg-koeln.nrw.de/brk_internet/geobasis/hoehenmodelle/digitale_gelaendemodelle/gelaendemodell/index.html">metadata</a></li>
@@ -26,10 +28,4 @@ r.import.dgm output=dgm_1m
 
 <h2>AUTHOR</h2>
 
-Guido Riembauer, mundialis, riembauer at mundialis.de
-
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Guido Riembauer, <a href="https://www.mundialis.de/">mundialis</a>, riembauer at mundialis.de

--- a/grass-gis-addons/r.import.ndom_nrw/r.import.ndom_nrw.html
+++ b/grass-gis-addons/r.import.ndom_nrw/r.import.ndom_nrw.html
@@ -1,10 +1,14 @@
 <h2>DESCRIPTION</h2>
 
-<em>r.import.ndom_nrw</em> calculates an nDOM by subtracting input DGM data (defined by the <b>dgm</b> parameter) from an input DOM indicated by the <b>dom</b> parameter.
-If no DGM is defined, NRW DGM data is automatically imported using <a href="r.import.dgm_nrw.html">r.import.dgm_nrw</a>.
-Potential NoData areas in the <b>dom</b> are filled beforehand by <a href="r.fillnulls.html">r.fillnulls</a>
-and both rasters are resampled to a common grid.
-The final nDOM is resampled to match the extent and resolution of the current computational region.
+<em>r.import.ndom_nrw</em> calculates an nDOM by subtracting input DGM
+data (defined by the <b>dgm</b> parameter) from an input DOM indicated
+by the <b>dom</b> parameter. If no DGM is defined, NRW DGM data is
+automatically imported using <a href="r.import.dgm_nrw.html">r.import.dgm_nrw</a>.
+Potential NoData areas in the <b>dom</b> are filled beforehand by
+<a href="r.fillnulls.html">r.fillnulls</a> and both rasters are resampled
+to a common grid. The final nDOM is resampled to match the extent and
+resolution of the current computational region.
+
 <h2>EXAMPLE</h2>
 
 <div class="code"><pre>
@@ -22,10 +26,4 @@ r.import.ndom_nrw dom=laz_import_dom output_ndom=ndom memory=8000
 
 <h2>AUTHOR</h2>
 
-Guido Riembauer, mundialis, riembauer at mundialis.de
-
-
-<!--
-<p>
-<i>Last changed: $Date$</i>
--->
+Guido Riembauer, <a href="https://www.mundialis.de/">mundialis</a>, riembauer at mundialis.de


### PR DESCRIPTION
This PR updates the manual pages, following
https://trac.osgeo.org/grass/wiki/Submitting/Docs#HTMLPages

- break long lines
- clean up of commands, HTML tags, empty lines
- complete mundialis' affiliation
- remove outdated commented `Date` cruft