### PR TITLE
nprocs parameter: standardize G_OPT_M_NPROCS

### DIFF
--- a/grass-gis-addons/m.analyse.buildings/r.extract.buildings/r.extract.buildings.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.buildings/r.extract.buildings.py
@@ -102,12 +102,7 @@
 # % guisection: Output
 # %end
 
-# %option
-# % key: nprocs
-# % type: integer
-# % required: no
-# % multiple: no
-# % label: Number of parallel processes
+# %option G_OPT_M_NPROCS
 # % description: Number of cores for multiprocessing, -2 is the number of available cores - 1
 # % answer: -2
 # %end

--- a/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs/r.extract.greenroofs.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs/r.extract.greenroofs.py
@@ -135,6 +135,7 @@
 # %end
 
 # %option G_OPT_M_NPROCS
+# % description: Number of cores for multiprocessing, -2 is the number of available cores - 1
 # % answer: -2
 # %end
 

--- a/grass-gis-addons/m.analyse.buildings/v.cd.areas/v.cd.areas.py
+++ b/grass-gis-addons/m.analyse.buildings/v.cd.areas/v.cd.areas.py
@@ -57,12 +57,7 @@
 # % guisection: Output
 # %end
 
-# %option
-# % key: nprocs
-# % type: integer
-# % required: no
-# % multiple: no
-# % label: Number of parallel processes
+# %option G_OPT_M_NPROCS
 # % description: Number of cores for multiprocessing, -2 is the number of available cores - 1
 # % answer: -2
 # %end

--- a/grass-gis-addons/m.analyse.trees/v.tree.param/v.tree.param.py
+++ b/grass-gis-addons/m.analyse.trees/v.tree.param/v.tree.param.py
@@ -65,12 +65,7 @@
 # % answer: 500
 # %end
 
-# %option
-# % key: nprocs
-# % type: integer
-# % required: no
-# % multiple: no
-# % label: Number of parallel processes
+# %option G_OPT_M_NPROCS
 # % description: Number of cores for multiprocessing, -2 is the number of available cores - 1
 # % answer: -2
 # %end

--- a/grass-gis-addons/m.import.rvr/m.import.rvr.py
+++ b/grass-gis-addons/m.import.rvr/m.import.rvr.py
@@ -149,7 +149,7 @@
 # %end
 
 # %option G_OPT_M_NPROCS
-# % description: Number of cores for multiprocessing, -2 is n_cores-1
+# % description: Number of cores for multiprocessing, -2 is the number of available cores - 1
 # % answer: -2
 # %end
 


### PR DESCRIPTION
Use the official parser macro and standardize the `nprocs` description.