### PR TITLE
GRASS addon to detect tree peaks from an ndsm

### DIFF
--- a/grass-gis-addons/m.analyse.trees/r.trees.peaks/Makefile
+++ b/grass-gis-addons/m.analyse.trees/r.trees.peaks/Makefile
@@ -1,4 +1,4 @@
-MODULE_TOPDIR = ../..
+MODULE_TOPDIR = ../../..
 
 PGM = r.trees.peaks
 

--- a/grass-gis-addons/m.analyse.trees/r.trees.peaks/r.trees.peaks.html
+++ b/grass-gis-addons/m.analyse.trees/r.trees.peaks/r.trees.peaks.html
@@ -1,7 +1,7 @@
 <h2>DESCRIPTION</h2>
 
 <em>r.trees.peaks</em> uses object heights from a normalized digital 
-surface model (nDSM) to detect peaks, to set uniques IDs for these peaks 
+surface model (nDSM) to detect peaks, to set unique IDs for these peaks 
 and to assign each pixel to the nearest peak using a cost analysis with 
 <a href="r.cost.html">r.cost</a> where inverted slope values are used 
 as costs.
@@ -17,6 +17,7 @@ r.trees.peaks ndsm=ndsm_raster nearest=nearest_tree peaks=tree_peaks slope=ndsm_
 <h2>SEE ALSO</h2>
 
 <em>
+<a href="m.analyse.trees.html">m.analyse.trees</a>,
 <a href="r.mapcalc.html">r.mapcalc</a>,
 <a href="r.cost.html">r.cost</a>,
 <a href="r.slope.aspect">r.slope.aspect</a>


### PR DESCRIPTION
The new addon `r.trees.peaks` detects peaks using geomorphology, assigns unique iDs to these peaks and sets for each pixel the ID of the nearest tree. "Nearest" is here defined similar to watershed segmentation and uses slope as costs to find the nearest (least costly to reach) peak.

The outputs are needed for 1) generation of training data for ML classification and 2) post-processing of the ML classification.