### PR TITLE
corrected module names 

### DIFF
--- a/grass-gis-addons/m.analyse.trees/v.trees.cd.worker/Makefile
+++ b/grass-gis-addons/m.analyse.trees/v.trees.cd.worker/Makefile
@@ -1,6 +1,6 @@
 MODULE_TOPDIR = ../..
 
-PGM = v.tree.cd
+PGM = v.trees.cd.worker
 
 include $(MODULE_TOPDIR)/include/Make/Script.make
 

--- a/grass-gis-addons/m.analyse.trees/v.trees.cd.worker/v.trees.cd.worker.html
+++ b/grass-gis-addons/m.analyse.trees/v.trees.cd.worker/v.trees.cd.worker.html
@@ -1,13 +1,13 @@
 <h2>DESCRIPTION</h2>
 
-<em>v.tree.cd.worker</em> is a worker module that is started by
-<a href="v.tree.cd.html">v.tree.cd</a>. 
+<em>v.trees.cd.worker</em> is a worker module that is started by
+<a href="v.trees.cd.html">v.trees.cd</a>. 
 
 <h2>SEE ALSO</h2>
 
 <em>
     <a href="https://grass.osgeo.org/grass-stable/manuals/v.overlay.html">v.overlay</a>,
-    <a href="v.tree.cd.html">v.tree.cd</a>
+    <a href="v.trees.cd.html">v.trees.cd</a>
 </em>
 
 <h2>AUTHORS</h2>

--- a/grass-gis-addons/m.analyse.trees/v.trees.cd.worker/v.trees.cd.worker.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.cd.worker/v.trees.cd.worker.py
@@ -2,7 +2,7 @@
 
 ############################################################################
 #
-# MODULE:       v.tree.cd.worker
+# MODULE:       v.trees.cd.worker
 #
 # AUTHOR(S):    Julia Haas and Lina Krisztian
 #

--- a/grass-gis-addons/m.analyse.trees/v.trees.cd/Makefile
+++ b/grass-gis-addons/m.analyse.trees/v.trees.cd/Makefile
@@ -1,6 +1,6 @@
 MODULE_TOPDIR = ../..
 
-PGM = v.tree.cd.worker
+PGM = v.trees.cd
 
 include $(MODULE_TOPDIR)/include/Make/Script.make
 

--- a/grass-gis-addons/m.analyse.trees/v.trees.cd/v.trees.cd.html
+++ b/grass-gis-addons/m.analyse.trees/v.trees.cd/v.trees.cd.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-<em>v.tree.cd</em> calculates the change between to given treecrown vector maps (<b>inp_t1</b> and <b>inp_t2</b> for time t1 and t2, respectively). <p>
+<em>v.trees.cd</em> calculates the change between to given treecrown vector maps (<b>inp_t1</b> and <b>inp_t2</b> for time t1 and t2, respectively). <p>
 It returns three vector maps: <i>&ltbasename&gt_congruent</i> for congruent trees, <i>&ltbasename&gt_only_&ltinp_t1&gt</i> for gone trees and <i>&ltbasename&gt_only_&ltinp_t2&gt</i> for new trees, 
 with <i>&ltbasename&gt</i> defined by <b>output</b>.
 For the congruent trees the parameter <b>vec_congr_thr</b> can be set, defining the threshold of overlap (in percentage) above which trees are considered to be congruent.
@@ -15,20 +15,20 @@ The calculation can be done in parallel on a grid, with the edge length of grid 
 <h3>Calculate change detection with tile_size of 500</h3>
 
 <div class="code"><pre>
-v.tree.cd inp_t1=treecrowns_2020 inp_t2=treecrowns_2022 output=cd_2020_2022 tile_size=500
+v.trees.cd inp_t1=treecrowns_2020 inp_t2=treecrowns_2022 output=cd_2020_2022 tile_size=500
 </pre></div>
 
 <h3>Calculate change detection with explicit values for filtering congruent and changed maps</h3>
 
 <div class="code"><pre>
-v.tree.cd inp_t1=treecrowns_2020 inp_t2=treecrowns_2022 output=cd_2020_2022 vec_congr_thr=80 vec_diff_min_size=1 tile_size=500
+v.trees.cd inp_t1=treecrowns_2020 inp_t2=treecrowns_2022 output=cd_2020_2022 vec_congr_thr=80 vec_diff_min_size=1 tile_size=500
 </pre></div>
 
 <h2>SEE ALSO</h2>
 
 <em>
 <a href="https://grass.osgeo.org/grass-stable/manuals/v.overlay.html">v.overlay</a>,
-<a href="v.tree.cd.worker.html">v.tree.cd.worker</a>
+<a href="v.trees.cd.worker.html">v.trees.cd.worker</a>
 </em>
 
 <h2>AUTHORS</h2>

--- a/grass-gis-addons/m.analyse.trees/v.trees.cd/v.trees.cd.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.cd/v.trees.cd.py
@@ -2,7 +2,7 @@
 
 ############################################################################
 #
-# MODULE:       v.tree.cd
+# MODULE:       v.trees.cd
 #
 # AUTHOR(S):    Julia Haas and Lina Krisztian
 #
@@ -315,7 +315,7 @@ def main():
                 "output_suffix": output_suffix,
             }
             v_tree_cd_worker = Module(
-                "v.tree.cd.worker",
+                "v.trees.cd.worker",
                 **param,
                 run_=False,
             )

--- a/grass-gis-addons/m.analyse.trees/v.trees.param.worker/Makefile
+++ b/grass-gis-addons/m.analyse.trees/v.trees.param.worker/Makefile
@@ -1,6 +1,6 @@
 MODULE_TOPDIR = ../..
 
-PGM = v.tree.param.worker
+PGM = v.trees.param.worker
 
 include $(MODULE_TOPDIR)/include/Make/Script.make
 

--- a/grass-gis-addons/m.analyse.trees/v.trees.param.worker/v.tree.param.worker.html
+++ b/grass-gis-addons/m.analyse.trees/v.trees.param.worker/v.tree.param.worker.html
@@ -1,12 +1,12 @@
 <h2>DESCRIPTION</h2>
 
-<em>v.tree.param.worker</em> is used within <em>v.tree.param</em> to calculate various tree parameters
+<em>v.trees.param.worker</em> is used within <em>v.trees.param</em> to calculate various tree parameters
 for tree crowns in parallel.
 
 <h2>SEE ALSO</h2>
 
 <em>
-  <a href="v.tree.param">v.tree.param</a>,
+  <a href="v.trees.param">v.trees.param</a>,
   <a href="https://grass.osgeo.org/grass-stable/manuals/v.to.db.html">v.to.db</a>,
   <a href="https://grass.osgeo.org/grass-stable/manuals/v.rast.stats.html">v.rast.stats</a>,
   <a href="https://grass.osgeo.org/grass-stable/manuals/r.distance.html">r.distance</a>,

--- a/grass-gis-addons/m.analyse.trees/v.trees.param.worker/v.tree.param.worker.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.param.worker/v.tree.param.worker.py
@@ -2,7 +2,7 @@
 
 ############################################################################
 #
-# MODULE:       v.tree.param.worker
+# MODULE:       v.trees.param.worker
 # AUTHOR(S):    Lina Krisztian
 #
 # PURPOSE:      Calculate various tree parameters

--- a/grass-gis-addons/m.analyse.trees/v.trees.param/Makefile
+++ b/grass-gis-addons/m.analyse.trees/v.trees.param/Makefile
@@ -1,6 +1,6 @@
 MODULE_TOPDIR = ../..
 
-PGM = v.tree.param
+PGM = v.trees.param
 
 include $(MODULE_TOPDIR)/include/Make/Script.make
 

--- a/grass-gis-addons/m.analyse.trees/v.trees.param/v.trees.param.html
+++ b/grass-gis-addons/m.analyse.trees/v.trees.param/v.trees.param.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-<em>v.tree.param</em> calculates various tree parameters for tree crowns given as input vector map <b>treecrowns</b>.
+<em>v.trees.param</em> calculates various tree parameters for tree crowns given as input vector map <b>treecrowns</b>.
 
 The module returns following parameters: 
 tree height, crown area, crown perimeter, NDVI per single tree, crown volume, stem position, distance to nearest building
@@ -23,25 +23,25 @@ Additionally the maximum memory to be used can be set by <b>memory</b>.
 <h3>Example 1:</h3>
 
 <div class="code"><pre>
-v.tree.param ndom=ndom ndvi=ndvi buildings=hausumringe treecrowns=trees
+v.trees.param ndom=ndom ndvi=ndvi buildings=hausumringe treecrowns=trees
 </pre></div>
 
 <h3>Example 2: run with 5 parallel processes</h3>
 
 <div class="code"><pre>
-v.tree.param ndom=ndom ndvi=ndvi buildings=hausumringe treecrowns=trees nprocs=5
+v.trees.param ndom=ndom ndvi=ndvi buildings=hausumringe treecrowns=trees nprocs=5
 </pre></div>
 
 <h3>Example 3: with optional input of <b>distance_tree</b> and  <b>distance_building</b></h3>
 
 <div class="code"><pre>
-v.tree.param ndom=ndom ndvi=ndvi buildings=hausumringe treecrowns=trees distance_tree=500 distance_building=500
+v.trees.param ndom=ndom ndvi=ndvi buildings=hausumringe treecrowns=trees distance_tree=500 distance_building=500
 </pre></div>
 
 <h2>SEE ALSO</h2>
 
 <em>
-  <a href="v.tree.param.worker">v.tree.param.worker</a>,
+  <a href="v.trees.param.worker">v.trees.param.worker</a>,
   <a href="https://grass.osgeo.org/grass-stable/manuals/v.to.db.html">v.to.db</a>,
   <a href="https://grass.osgeo.org/grass-stable/manuals/v.rast.stats.html">v.rast.stats</a>,
   <a href="https://grass.osgeo.org/grass-stable/manuals/r.distance.html">r.distance</a>,

--- a/grass-gis-addons/m.analyse.trees/v.trees.param/v.trees.param.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.param/v.trees.param.py
@@ -2,7 +2,7 @@
 
 ############################################################################
 #
-# MODULE:       v.tree.param
+# MODULE:       v.trees.param
 # AUTHOR(S):    Lina Krisztian
 #
 # PURPOSE:      Calculate various tree parameters
@@ -223,7 +223,7 @@ def main():
             if distance_tree:
                 param["distance_tree"] = distance_tree
             v_tree_param = Module(
-                "v.tree.param.worker",
+                "v.trees.param.worker",
                 **param,
                 new_mapset=new_mapset,
                 memory=use_memory,


### PR DESCRIPTION
`v.tree.cd` to `v.trees.cd`
`v.tree.cd.worker` to `v.trees.cd.worker`
`v.tree.param` to `v.trees.param`
`v.tree.param.worker` to `v.trees.param.worker`