### PR TITLE
Add parameter to import DTM xyz files from directory

### DIFF
--- a/grass-gis-addons/m.import.rvr/m.import.rvr.py
+++ b/grass-gis-addons/m.import.rvr/m.import.rvr.py
@@ -991,7 +991,6 @@ def import_xyz_from_dir(data, src_res, dest_res, output_name, study_area=None):
                 "v.import",
                 input=tindex_file,
                 output=f"{output_name}_tindex",
-                flags="o",
                 quiet=True,
                 overwrite=True,
             )


### PR DESCRIPTION
The DTM could be a raster Tif or XYZ or several XYZ files.
The possibility to set the parameter `dtm_file` to a directory with several XYZ files is added. For this the tile index can be given or saved by setting the `dtm_tindex`.