### PR TITLE
new_mapset is not required

### DIFF
--- a/grass-gis-addons/r.in.pdal.worker/r.in.pdal.worker.py
+++ b/grass-gis-addons/r.in.pdal.worker/r.in.pdal.worker.py
@@ -31,7 +31,7 @@
 # %option
 # % key: new_mapset
 # % type: string
-# % required: yes
+# % required: no
 # % multiple: no
 # % label: Name of new mapset where to compute the building MASK
 # %end


### PR DESCRIPTION
The option `new_mapset` is not required by `r.in.pdal.worker` because there are tests if this option is set in https://github.com/mundialis/rvr_interface/blob/28f2a2f6bfd04fcb8cac025fde85a251f21d4944/grass-gis-addons/r.in.pdal.worker/r.in.pdal.worker.py#L387 and https://github.com/mundialis/rvr_interface/blob/28f2a2f6bfd04fcb8cac025fde85a251f21d4944/grass-gis-addons/r.in.pdal.worker/r.in.pdal.worker.py#L424