### PR TITLE
improve calculation of tree diameter

### DIFF
--- a/grass-gis-addons/m.analyse.trees/v.trees.param.worker/v.trees.param.worker.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.param.worker/v.trees.param.worker.py
@@ -215,7 +215,7 @@ def crowndiameter(list_attr, treecrowns):
     grass.run_command(
         "v.to.db",
         map=treecrowns,
-        option="perimeter",
+        option="area",
         columns=col_diameter,
         quiet=True,
     )
@@ -224,7 +224,7 @@ def crowndiameter(list_attr, treecrowns):
         "v.db.update",
         map=treecrowns,
         column=col_diameter,
-        query_column=f"{col_diameter}/{math.pi}",
+        query_column=f"2*(sqrt({col_diameter}/{math.pi}))",
     )
     grass.message(_("Crown diameter was calculated."))
     return col_diameter


### PR DESCRIPTION
An estimation of the tree diameter via the area is more appropriate, since the circumference probably overestimates the diameter significantly due to the complexity of the circumference line.

A comparison shows the differences between the two calculation methods:

- `diameter_peri` is the diameter calculated with the circumference,
- `diameter_area` calculated with the area

![tree_diameter](https://github.com/mundialis/rvr_interface/assets/83269984/2019b990-72ce-4d27-b546-ea5980bc4179)
