### PR TITLE
unify parameters for buildings addons

### DIFF
--- a/grass-gis-addons/m.analyse.buildings/r.extract.buildings.worker/r.extract.buildings.worker.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.buildings.worker/r.extract.buildings.worker.py
@@ -40,37 +40,29 @@
 
 # %option G_OPT_R_INPUT
 # % key: ndsm
-# % type: string
-# % required: yes
-# % label: Name of the nDSM
+# % label: Name of the nDSM raster
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndvi_raster
-# % type: string
-# % required: yes
 # % label: Name of the NDVI raster
 # %end
 
 # %option G_OPT_V_INPUT
 # % key: fnk_vector
-# % type: string
 # % required: no
-# % label: Vector map containing Flaechennutzungskartierung
+# % label: Name of vector map containing the Flaechennutzungskartierung
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: fnk_raster
-# % type: string
 # % required: no
-# % label: Raster map containing Flaechennutzungskartierung
+# % label: Name of raster map containing the Flaechennutzungskartierung
 # %end
 
-# %option G_OPT_R_INPUT
+# %option G_OPT_DB_COLUMN
 # % key: fnk_column
-# % type: string
-# % required: no
-# % label: Integer column containing FNK-code
+# % label: Name of integer column containing FNK-code
 # %end
 
 # %option
@@ -101,8 +93,6 @@
 
 # %option G_OPT_R_OUTPUT
 # % key: output
-# % type: string
-# % required: yes
 # % label: Name for output vector map
 # %end
 

--- a/grass-gis-addons/m.analyse.buildings/r.extract.buildings.worker/r.extract.buildings.worker.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.buildings.worker/r.extract.buildings.worker.py
@@ -68,7 +68,7 @@
 # %option
 # % key: min_size
 # % type: integer
-# % required: no
+# % required: yes
 # % multiple: no
 # % label: Minimum size of buildings in sqm
 # % answer: 20
@@ -77,7 +77,7 @@
 # %option
 # % key: max_fd
 # % type: double
-# % required: no
+# % required: yes
 # % multiple: no
 # % label: Maximum value of fractal dimension of identified objects (see v.to.db)
 # % answer: 2.1

--- a/grass-gis-addons/m.analyse.buildings/r.extract.buildings/r.extract.buildings.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.buildings/r.extract.buildings.py
@@ -56,7 +56,7 @@
 # %option
 # % key: min_size
 # % type: integer
-# % required: no
+# % required: yes
 # % multiple: no
 # % label: Minimum size of buildings in sqm
 # % answer: 20
@@ -66,7 +66,7 @@
 # %option
 # % key: max_fd
 # % type: double
-# % required: no
+# % required: yes
 # % multiple: no
 # % label: Maximum value of fractal dimension of identified objects (see v.to.db)
 # % answer: 2.1

--- a/grass-gis-addons/m.analyse.buildings/r.extract.buildings/r.extract.buildings.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.buildings/r.extract.buildings.py
@@ -26,35 +26,30 @@
 
 # %option G_OPT_R_INPUT
 # % key: ndsm
-# % type: string
-# % required: yes
 # % label: Name of the nDSM raster
+# % answer: ndsm
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndvi_raster
-# % type: string
-# % required: yes
 # % label: Name of the NDVI raster
+# % answer: dop_ndvi_05
 # % guisection: Input
 # %end
 
 # %option G_OPT_V_INPUT
 # % key: fnk_vector
-# % type: string
-# % required: yes
-# % label: Vector map containing Flaechennutzungskartierung
+# % label: Name of vector map containing the Flaechennutzungskartierung
+# % answer: fnk
 # % guisection: Input
 # % guidependency: fnk_column
 # %end
 
 # %option G_OPT_DB_COLUMN
 # % key: fnk_column
-# % type: string
 # % required: yes
-# % multiple: no
-# % label: Integer column containing FNK-code
+# % label: Name of integer column containing FNK-code
 # % guisection: Input
 # %end
 
@@ -79,28 +74,29 @@
 # %end
 
 # %option
-# % key: ndvi_thresh
-# % type: integer
-# % required: no
-# % multiple: no
-# % label: Define fix NDVI threshold (on a scale from 0-255) instead of estimating it from FNK
-# % guisection: Parameters
-# %end
-
-# %option
 # % key: ndvi_perc
 # % type: integer
 # % required: no
 # % multiple: no
 # % label: NDVI percentile in vegetated areas to use for thresholding
+# TODO: make radio button and add default
+# # % answer: 5
+# % guisection: Parameters
+# %end
+
+# %option
+# % key: ndvi_thresh
+# % type: integer
+# % required: no
+# % multiple: no
+# % label: Fix NDVI threshold (on a scale from 0-255) instead of estimated value from ndvi_perc and FNK
+# TODO: make radio button and add default
+# # % answer: 145
 # % guisection: Parameters
 # %end
 
 # %option G_OPT_V_OUTPUT
-# % key: output
-# % type: string
-# % required: yes
-# % label: Name for output vector map
+# % answer: buildings_Bottrop_2017
 # % guisection: Output
 # %end
 
@@ -119,7 +115,7 @@
 # % type: integer
 # % required: yes
 # % multiple: no
-# % label: Define edge length of grid tiles for parallel processing
+# % label: Edge length of grid tiles for parallel processing
 # % answer: 1000
 # % guisection: Parallel processing
 # %end
@@ -638,7 +634,7 @@ def main():
         quiet=True,
     )
 
-    grass.message(_(f"Created output vector layer {output_vect}"))
+    grass.message(_(f"Created output vector layer <{output_vect}>."))
 
 
 if __name__ == "__main__":

--- a/grass-gis-addons/m.analyse.buildings/r.extract.buildings/r.extract.buildings.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.buildings/r.extract.buildings.py
@@ -96,7 +96,7 @@
 # %end
 
 # %option G_OPT_V_OUTPUT
-# % answer: buildings_Bottrop_2017
+# % answer: buildings
 # % guisection: Output
 # %end
 

--- a/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs.worker/r.extract.greenroofs.worker.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs.worker/r.extract.greenroofs.worker.py
@@ -24,6 +24,11 @@
 # % keyword: worker
 # %end
 
+# %option G_OPT_V_INPUT
+# % key: area
+# % label: Vector map containing area
+# %end
+
 # %option
 # % key: new_mapset
 # % type: string
@@ -33,58 +38,37 @@
 # %end
 
 # %option G_OPT_V_INPUT
-# % key: area
-# % type: string
-# % required: yes
-# % label: Vector map containing area
-# %end
-
-# %option G_OPT_V_INPUT
 # % key: building_outlines
-# % type: string
-# % required: yes
 # % label: Name of vector map containing outlines of buildings
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: buildings
-# % type: string
-# % required: yes
 # % label: Name of raster map containing buildings
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndsm
-# % type: string
-# % required: yes
 # % label: Name of the nDSM raster
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: gb_ratio
-# % type: string
-# % required: yes
 # % label: Name of the GB-ratio raster
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: rg_ratio
-# % type: string
-# % required: yes
 # % label: Name of the RG-ratio raster
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: brightness
-# % type: string
-# % required: yes
 # % label: Name of the brightness raster
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndvi
-# % type: string
-# % required: yes
 # % label: Name of the NDVI raster
 # %end
 
@@ -140,7 +124,6 @@
 
 # %option G_OPT_V_OUTPUT
 # % key: output_vegetation
-# % required: yes
 # % label: Name for output roof vegetation vector map
 # %end
 

--- a/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs.worker/r.extract.greenroofs.worker.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs.worker/r.extract.greenroofs.worker.py
@@ -43,14 +43,14 @@
 # % key: building_outlines
 # % type: string
 # % required: yes
-# % label: Vector map containing outlines of buildings
+# % label: Name of vector map containing outlines of buildings
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: buildings
 # % type: string
 # % required: yes
-# % label: Raster map containing buildings
+# % label: Name of raster map containing buildings
 # %end
 
 # %option G_OPT_R_INPUT
@@ -93,7 +93,7 @@
 # % type: integer
 # % required: yes
 # % multiple: no
-# % label: Define fix Green_blue_ratio threshold (on a scale from 0-255)
+# % label: Fix value for green-blue-ratio threshold (on a scale from 0-255)
 # %end
 
 # %option
@@ -101,7 +101,7 @@
 # % type: integer
 # % required: no
 # % multiple: no
-# % label: Define fix nDSM median
+# % label: Value for nDSM median
 # %end
 
 # %option
@@ -109,7 +109,7 @@
 # % type: integer
 # % required: no
 # % multiple: no
-# % label: Define fix nDSM low percentile
+# % label: Fix value for nDSM low percentile
 # %end
 
 # %option
@@ -117,7 +117,7 @@
 # % type: integer
 # % required: no
 # % multiple: no
-# % label: Define fix nDSM high percentile
+# % label: Fix value for nDSM high percentile
 # %end
 
 # %option
@@ -141,7 +141,7 @@
 # %option G_OPT_V_OUTPUT
 # % key: output_vegetation
 # % required: yes
-# % label: Name of output roof vegetation vector map
+# % label: Name for output roof vegetation vector map
 # %end
 
 # %option G_OPT_MEMORYMB

--- a/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs/r.extract.greenroofs.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs/r.extract.greenroofs.py
@@ -94,7 +94,8 @@
 # % type: integer
 # % required: no
 # % multiple: no
-# % label: Green-Blue-Ratio threshold as this percentile of green areas
+# % label: Green-Blue-Ratio percentile in green areas to use for thresholding
+
 # TODO: make radio button and add default
 # # % answer: 25
 # % guisection: Parameters
@@ -114,7 +115,7 @@
 # %option
 # % key: min_veg_size
 # % type: integer
-# % required: no
+# % required: yes
 # % multiple: no
 # % label: Minimum size of roof vegetation in sqm
 # % answer: 5
@@ -124,7 +125,7 @@
 # %option
 # % key: min_veg_proportion
 # % type: integer
-# % required: no
+# % required: yes
 # % multiple: no
 # % label: Minimum percentage of vegetation cover on roof
 # % answer: 10

--- a/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs/r.extract.greenroofs.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs/r.extract.greenroofs.py
@@ -28,85 +28,65 @@
 
 # %option G_OPT_R_INPUT
 # % key: ndsm
-# % type: string
-# % required: yes
 # % label: Name of the nDSM raster
+# % answer: ndsm
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndvi
-# % type: string
-# % required: yes
 # % label: Name of the NDVI raster
+# % answer: dop_ndvi_05
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: red
-# % type: string
-# % required: yes
 # % label: Name of the red DOP raster
+# % answer: dop_red_05
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: green
-# % type: string
-# % required: yes
 # % label: Name of the green DOP raster
+# % answer: dop_green_05
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: blue
-# % type: string
-# % required: yes
 # % label: Name of the blue DOP raster
+# % answer: dop_blue_05
 # % guisection: Input
 # %end
 
 # %option G_OPT_V_INPUT
 # % key: fnk
-# % type: string
 # % required: no
-# % label: Vector map containing Flaechennutzungskartierung
+# % label: Name of vector map containing the Flaechennutzungskartierung
 # % guisection: Optional input
 # % guidependency: fnk_column
 # %end
 
 # %option G_OPT_DB_COLUMN
 # % key: fnk_column
-# % type: string
-# % required: no
-# % multiple: no
-# % label: Integer column containing FNK-code
+# % label: Name of integer column containing FNK-code
 # % guisection: Optional input
 # %end
 
 # %option G_OPT_V_INPUT
 # % key: buildings
-# % type: string
-# % required: yes
-# % label: Vector map containing outlines of buildings
+# % label: Name of vector map containing outlines of buildings
+# % answer: building_outlines
 # % guisection: Input
 # %end
 
 # %option G_OPT_V_INPUT
 # % key: trees
-# % type: string
 # % required: no
 # % label: Vector map containing tree polygons
 # % guisection: Optional input
-# %end
-
-# %option
-# % key: gb_thresh
-# % type: integer
-# % required: no
-# % multiple: no
-# % label: Define fix Green-Blue-Ratio threshold (on a scale from 0-255)
-# % guisection: Parameters
 # %end
 
 # %option
@@ -114,14 +94,27 @@
 # % type: integer
 # % required: no
 # % multiple: no
-# % label: Define Green-Blue-Ratio threshold as this percentile of green areas
+# % label: Green-Blue-Ratio threshold as this percentile of green areas
+# TODO: make radio button and add default
+# # % answer: 25
+# % guisection: Parameters
+# %end
+
+# %option
+# % key: gb_thresh
+# % type: integer
+# % required: no
+# % multiple: no
+# % label: Fix Green-Blue-Ratio threshold (on a scale from 0-255)
+# TODO: make radio button and add default
+# # % answer: 145
 # % guisection: Parameters
 # %end
 
 # %option
 # % key: min_veg_size
 # % type: integer
-# % required: yes
+# % required: no
 # % multiple: no
 # % label: Minimum size of roof vegetation in sqm
 # % answer: 5
@@ -131,7 +124,7 @@
 # %option
 # % key: min_veg_proportion
 # % type: integer
-# % required: yes
+# % required: no
 # % multiple: no
 # % label: Minimum percentage of vegetation cover on roof
 # % answer: 10
@@ -140,15 +133,15 @@
 
 # %option G_OPT_V_OUTPUT
 # % key: output_buildings
-# % required: yes
-# % label: Name of output building vector map
+# % label: Name for output buildings vector map
+# % answer: buildings_with_green_roofs
 # % guisection: Output
 # %end
 
 # %option G_OPT_V_OUTPUT
 # % key: output_vegetation
-# % required: yes
-# % label: Name of output roof vegetation vector map
+# % label: Name for output roof vegetation vector map
+# % answer: green_roofs
 # % guisection: Output
 # %end
 

--- a/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs/r.extract.greenroofs.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs/r.extract.greenroofs.py
@@ -23,7 +23,7 @@
 # % keyword: classification
 # % keyword: statistics
 # % keyword: buildings analysis
-# % keyword: greenroofs
+# % keyword: green roofs
 # %end
 
 # %option G_OPT_R_INPUT

--- a/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs/r.extract.greenroofs.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.greenroofs/r.extract.greenroofs.py
@@ -95,7 +95,6 @@
 # % required: no
 # % multiple: no
 # % label: Green-Blue-Ratio percentile in green areas to use for thresholding
-
 # TODO: make radio button and add default
 # # % answer: 25
 # % guisection: Parameters

--- a/grass-gis-addons/m.analyse.buildings/v.cd.areas.worker/v.cd.areas.worker.py
+++ b/grass-gis-addons/m.analyse.buildings/v.cd.areas.worker/v.cd.areas.worker.py
@@ -26,6 +26,11 @@
 # % keyword: worker
 # %end
 
+# %option G_OPT_V_INPUT
+# % key: area
+# % description: Input natural tiles as vector map
+# %end
+
 # %option
 # % key: new_mapset
 # % type: string
@@ -33,11 +38,6 @@
 # % multiple: no
 # % key_desc: name
 # % description: Name for new mapset
-# %end
-
-# %option G_OPT_V_INPUT
-# % key: area
-# % description: Input natural tiles as vector map
 # %end
 
 # %option G_OPT_V_INPUT

--- a/grass-gis-addons/m.analyse.buildings/v.cd.areas/v.cd.areas.py
+++ b/grass-gis-addons/m.analyse.buildings/v.cd.areas/v.cd.areas.py
@@ -42,7 +42,7 @@
 # %option
 # % key: min_size
 # % type: integer
-# % required: no
+# % required: yes
 # % multiple: no
 # % label: Minimum size of identified change areas in sqm
 # % answer: 5
@@ -52,7 +52,7 @@
 # %option
 # % key: max_fd
 # % type: double
-# % required: no
+# % required: yes
 # % multiple: no
 # % label: Maximum value of fractal dimension of identified change areas (see v.to.db)
 # % answer: 2.5

--- a/grass-gis-addons/m.analyse.buildings/v.cd.areas/v.cd.areas.py
+++ b/grass-gis-addons/m.analyse.buildings/v.cd.areas/v.cd.areas.py
@@ -28,7 +28,7 @@
 
 # %option G_OPT_V_INPUT
 # %label: Name of the input vector layer
-# % answer: buildings_Bottrop_2017
+# % answer: buildings
 # % guisection: Input
 # %end
 
@@ -60,7 +60,7 @@
 # %end
 
 # %option G_OPT_V_OUTPUT
-# % answer: buildings_alkis_diff_Bottrop_2017
+# % answer: buildings_difference
 # % guisection: Output
 # %end
 

--- a/grass-gis-addons/m.analyse.buildings/v.cd.areas/v.cd.areas.py
+++ b/grass-gis-addons/m.analyse.buildings/v.cd.areas/v.cd.areas.py
@@ -28,12 +28,14 @@
 
 # %option G_OPT_V_INPUT
 # %label: Name of the input vector layer
+# % answer: buildings_Bottrop_2017
 # % guisection: Input
 # %end
 
 # %option G_OPT_V_INPUT
 # % key: reference
 # % label: Name of the reference vector layer
+# % answer: reference_buildings
 # % guisection: Input
 # %end
 
@@ -58,6 +60,7 @@
 # %end
 
 # %option G_OPT_V_OUTPUT
+# % answer: buildings_alkis_diff_Bottrop_2017
 # % guisection: Output
 # %end
 
@@ -467,7 +470,7 @@ def main():
     keepcols = ("cat", "floors", area_col, fd_col, "source")
     clean_columns(map=cd_output, keepcolumns=keepcols)
 
-    grass.message(_(f"Created output vector map <{cd_output}>"))
+    grass.message(_(f"Created output vector map <{cd_output}>."))
 
     if flags["q"]:
         # quality assessment: calculate completeness and correctness

--- a/grass-gis-addons/m.import.rvr/m.import.rvr.py
+++ b/grass-gis-addons/m.import.rvr/m.import.rvr.py
@@ -33,7 +33,6 @@
 # % required: yes
 # % multiple: yes
 # % label: Type of processing for which the data should be imported
-# TODO: umbenennen
 # % options: gebaeudedetektion,dachbegruenung,einzelbaumerkennung
 # % guisection: General input
 # %end

--- a/grass-gis-addons/m.import.rvr/m.import.rvr.py
+++ b/grass-gis-addons/m.import.rvr/m.import.rvr.py
@@ -33,6 +33,7 @@
 # % required: yes
 # % multiple: yes
 # % label: Type of processing for which the data should be imported
+# TODO: umbenennen
 # % options: gebaeudedetektion,dachbegruenung,einzelbaumerkennung
 # % guisection: General input
 # %end


### PR DESCRIPTION
MR unifys parameters for the buildings addons (`m.analyse.buildings`), especially it:

* labels parameters as required
* uses parser standard options
* renames parameters, options etc. to English
* adapts/unifys label text
* reorders some parameters
* sets default values for required parameters
  * if output is previously set to default, then this value is set as input in next addon -> note: if output is named differently by the user, then default input must also be adjusted for the next module