### PR TITLE
unify parameters for tree addons

### DIFF
--- a/grass-gis-addons/m.analyse.buildings/r.extract.buildings/r.extract.buildings.py
+++ b/grass-gis-addons/m.analyse.buildings/r.extract.buildings/r.extract.buildings.py
@@ -119,7 +119,7 @@
 # % type: integer
 # % required: yes
 # % multiple: no
-# % label: Define edge length of grid tiles for parallel processing
+# % label: Edge length of grid tiles for parallel processing
 # % answer: 1000
 # % guisection: Parallel processing
 # %end

--- a/grass-gis-addons/m.analyse.trees/r.trees.mlapply.worker/r.trees.mlapply.worker.py
+++ b/grass-gis-addons/m.analyse.trees/r.trees.mlapply.worker/r.trees.mlapply.worker.py
@@ -38,6 +38,14 @@
 # % description: Input natural tiles as vector map
 # %end
 
+# %option
+# % key: new_mapset
+# % type: string
+# % required: yes
+# % key_desc: name
+# % description: Name for new mapset
+# %end
+
 # %option G_OPT_I_GROUP
 # % key: group
 # % multiple: no
@@ -54,14 +62,6 @@
 # % key: output
 # % multiple: no
 # % description: Name of classified output raster map
-# %end
-
-# %option
-# % key: new_mapset
-# % type: string
-# % required: yes
-# % key_desc: name
-# % description: Name for new mapset
 # %end
 
 import sys

--- a/grass-gis-addons/m.analyse.trees/r.trees.mlapply/r.trees.mlapply.py
+++ b/grass-gis-addons/m.analyse.trees/r.trees.mlapply/r.trees.mlapply.py
@@ -4,7 +4,7 @@
 #
 # MODULE:       r.trees.mlapply
 #
-# AUTHOR(S):    Julia Haas, Markus Metz, Lina Krisztian
+# AUTHOR(S):    Markus Metz, Lina Krisztian, Julia Haas
 #
 # PURPOSE:      Applies the tree classification model in parallel to the
 #               current region
@@ -36,24 +36,28 @@
 # %option G_OPT_V_INPUT
 # % key: area
 # % label: Name of vector defining area of interest
+# % answer: study_area
 # % guisection: Input
 # %end
 
 # %option G_OPT_I_GROUP
 # % key: group
 # % label: Name of input group
+# % answer: ml_input
 # % guisection: Input
 # %end
 
 # %option G_OPT_F_INPUT
 # % key: model
 # % label: Name of input model file
+# % answer: gelsenkirchen_2020_ml_trees_randomforest.gz
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_OUTPUT
 # % key: output
 # % label: Name of classified output raster map
+# % answer: tree_pixels
 # % guisection: Output
 # %end
 
@@ -67,8 +71,8 @@
 # % key: tile_size
 # % type: double
 # % required: no
-# % answer: 1000
 # % label: Edge length of grid tiles in map units for parallel processing
+# % answer: 1000
 # % guisection: Parallel processing
 # %end
 

--- a/grass-gis-addons/m.analyse.trees/r.trees.mlapply/r.trees.mlapply.py
+++ b/grass-gis-addons/m.analyse.trees/r.trees.mlapply/r.trees.mlapply.py
@@ -50,7 +50,7 @@
 # %option G_OPT_F_INPUT
 # % key: model
 # % label: Name of input model file
-# % answer: gelsenkirchen_2020_ml_trees_randomforest.gz
+# % answer: ml_trees_randomforest.gz
 # % guisection: Input
 # %end
 

--- a/grass-gis-addons/m.analyse.trees/r.trees.mltrain/r.trees.mltrain.py
+++ b/grass-gis-addons/m.analyse.trees/r.trees.mltrain/r.trees.mltrain.py
@@ -27,64 +27,64 @@
 
 # %option G_OPT_R_INPUT
 # % key: red_raster
-# % required: yes
-# % label: Name of the red band
+# % label: Name of the red raster
+# % answer: top_red_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: green_raster
-# % required: yes
-# % label: Name of the green band
+# % label: Name of the green raster
+# % answer: top_green_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: blue_raster
-# % required: yes
-# % label: Name of the blue band
+# % label: Name of the blue raster
+# % answer: top_blue_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: nir_raster
-# % required: yes
 # % label: Name of the NIR raster
+# % answer: top_nir_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndvi_raster
-# % required: yes
 # % label: Name of the NDVI raster
+# % answer: top_ndvi_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndsm
-# % required: yes
 # % label: Name of the nDSM raster
+# % answer: ndsm
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: slope
-# % required: yes
 # % label: Name of the nDSM slope raster
+# % answer: ndsm_slope
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: nearest
-# % required: yes
 # % label: Name of raster with nearest peak IDs
+# % answer: nearest_tree
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: peaks
-# % required: yes
 # % label: Name of raster with peaks and ridges
+# % answer: tree_peaks
 # % guisection: Input
 # %end
 
@@ -102,12 +102,11 @@
 # % guisection: Optional input
 # %end
 
-
 # %option
 # % key: ndvi_threshold
 # % type: double
-# % required: no
-# % label: Define NDVI threshold for potential trees
+# % required: yes
+# % label: NDVI threshold for potential trees
 # % answer: 130
 # % guisection: Parameters
 # %end
@@ -115,8 +114,8 @@
 # %option
 # % key: nir_threshold
 # % type: double
-# % required: no
-# % label: Define NIR threshold for potential trees
+# % required: yes
+# % label: NIR threshold for potential trees
 # % answer: 130
 # % guisection: Parameters
 # %end
@@ -124,8 +123,8 @@
 # %option
 # % key: ndsm_threshold
 # % type: double
-# % required: no
-# % label: Define nDSM threshold for potential trees
+# % required: yes
+# % label: nDSM threshold for potential trees
 # % answer: 1
 # % guisection: Parameters
 # %end
@@ -133,8 +132,8 @@
 # %option
 # % key: slopep75_threshold
 # % type: double
-# % required: no
-# % label: Define threshold for 75 percentile of slope for potential trees
+# % required: yes
+# % label: Threshold for 75 percentile of slope for potential trees
 # % answer: 70
 # % guisection: Parameters
 # %end
@@ -142,8 +141,8 @@
 # %option
 # % key: area_threshold
 # % type: double
-# % required: no
-# % label: Define area size threshold for potential trees
+# % required: yes
+# % label: Area size threshold for potential trees
 # % answer: 5
 # % guisection: Parameters
 # %end
@@ -151,10 +150,10 @@
 # %option
 # % key: group
 # % type: string
-# % required: no
-# % answer: ml_input
+# % required: yes
 # % gisprompt: new,group,group
 # % label: Name of output imagery group
+# % answer: ml_input
 # % guisection: Output
 # %end
 
@@ -162,7 +161,7 @@
 # % key: save_model
 # % label: Save model to file (for compression use e.g. '.gz' extension)
 # % description: Name of file to store model results using python joblib
-# % required: yes
+# % answer: gelsenkirchen_2020_ml_trees_randomforest.gz
 # % guisection: Output
 # %end
 

--- a/grass-gis-addons/m.analyse.trees/r.trees.mltrain/r.trees.mltrain.py
+++ b/grass-gis-addons/m.analyse.trees/r.trees.mltrain/r.trees.mltrain.py
@@ -161,7 +161,7 @@
 # % key: save_model
 # % label: Save model to file (for compression use e.g. '.gz' extension)
 # % description: Name of file to store model results using python joblib
-# % answer: gelsenkirchen_2020_ml_trees_randomforest.gz
+# % answer: ml_trees_randomforest.gz
 # % guisection: Output
 # %end
 

--- a/grass-gis-addons/m.analyse.trees/r.trees.peaks/r.trees.peaks.py
+++ b/grass-gis-addons/m.analyse.trees/r.trees.peaks/r.trees.peaks.py
@@ -27,34 +27,31 @@
 
 # %option G_OPT_R_INPUT
 # % key: ndsm
-# % type: string
-# % required: yes
 # % multiple: no
 # % label: Name of the nDSM raster
+# % answer: ndsm
 # % guisection: Input
 # %end
 
 # %option G_OPT_V_INPUT
 # % key: area
-# % answer: study_area
-# % required: no
+# % required: yes
 # % label: Name of vector defining area of interest
+# % answer: study_area
 # % guisection: Optional input
 # %end
 
 # %option
 # % key: forms_res
 # % type: double
-# % required: no
+# % required: yes
 # % label: Resolution to use for forms detection
 # % answer: 0.8
 # % guisection: Optional input
 # %end
 
-
 # %option G_OPT_R_OUTPUT
 # % key: nearest
-# % required: yes
 # % multiple: no
 # % label: Output raster map with ID of nearest tree
 # % answer: nearest_tree
@@ -63,17 +60,17 @@
 
 # %option G_OPT_R_OUTPUT
 # % key: peaks
-# % required: yes
 # % multiple: no
 # % label: Output raster map with peaks and ridges
+# % answer: tree_peaks
 # % guisection: Output
 # %end
 
 # %option G_OPT_R_OUTPUT
 # % key: slope
-# % required: yes
 # % multiple: no
 # % label: Output raster map with nDSM slope
+# % answer: ndsm_slope
 # % guisection: Output
 # %end
 
@@ -91,8 +88,8 @@
 # % key: tile_size
 # % type: double
 # % required: no
-# % answer: 2000
 # % label: Edge length of grid tiles in map units for parallel processing
+# % answer: 2000
 # % guisection: Parallel processing
 # %end
 

--- a/grass-gis-addons/m.analyse.trees/r.trees.peaks/r.trees.peaks.py
+++ b/grass-gis-addons/m.analyse.trees/r.trees.peaks/r.trees.peaks.py
@@ -25,20 +25,20 @@
 # % keyword: trees analysis
 # %end
 
-# %option G_OPT_R_INPUT
-# % key: ndsm
-# % multiple: no
-# % label: Name of the nDSM raster
-# % answer: ndsm
-# % guisection: Input
-# %end
-
 # %option G_OPT_V_INPUT
 # % key: area
 # % required: yes
 # % label: Name of vector defining area of interest
 # % answer: study_area
 # % guisection: Optional input
+# %end
+
+# %option G_OPT_R_INPUT
+# % key: ndsm
+# % multiple: no
+# % label: Name of the nDSM raster
+# % answer: ndsm
+# % guisection: Input
 # %end
 
 # %option

--- a/grass-gis-addons/m.analyse.trees/r.trees.postprocess/r.trees.postprocess.py
+++ b/grass-gis-addons/m.analyse.trees/r.trees.postprocess/r.trees.postprocess.py
@@ -27,65 +27,65 @@
 
 # %option G_OPT_R_INPUT
 # % key: tree_pixels
-# % required: yes
 # % label: Name of the tree raster
 # % description: Non-tree pixels must be NULL
+# % answer: tree_pixels
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: green_raster
-# % required: yes
-# % label: Name of the green band
+# % label: Name of the green raster
+# % answer: top_green_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: blue_raster
-# % required: yes
-# % label: Name of the blue band
+# % label: Name of the blue raster
+# % answer: top_blue_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: nir_raster
-# % required: yes
 # % label: Name of the NIR raster
+# % answer: top_nir_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndvi_raster
-# % required: yes
 # % label: Name of the NDVI raster
+# % answer: top_ndvi_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndsm
-# % required: yes
 # % label: Name of the NDSM raster
+# % answer: ndsm
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: slope
-# % required: yes
 # % label: Name of the nDSM slope raster
+# % answer: ndsm_slope
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: nearest
-# % required: yes
 # % label: Name of raster with nearest peak IDs
+# % answer: nearest_tree
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: peaks
-# % required: yes
 # % label: Name of raster with peaks and ridges
+# % answer: tree_peaks
 # % guisection: Input
 # %end
 
@@ -106,8 +106,8 @@
 # %option
 # % key: ndvi_threshold
 # % type: double
-# % required: no
-# % label: Define NDVI threshold for potential trees
+# % required: yes
+# % label: NDVI threshold for potential trees
 # % answer: 130
 # % guisection: Parameters
 # %end
@@ -115,8 +115,8 @@
 # %option
 # % key: nir_threshold
 # % type: double
-# % required: no
-# % label: Define NIR threshold for potential trees
+# % required: yes
+# % label: NIR threshold for potential trees
 # % answer: 130
 # % guisection: Parameters
 # %end
@@ -124,8 +124,8 @@
 # %option
 # % key: ndsm_threshold
 # % type: double
-# % required: no
-# % label: Define nDSM threshold for potential trees
+# % required: yes
+# % label: nDSM threshold for potential trees
 # % answer: 1
 # % guisection: Parameters
 # %end
@@ -133,8 +133,8 @@
 # %option
 # % key: slopep75_threshold
 # % type: double
-# % required: no
-# % label: Define threshold for 75 percentile of slope for potential trees
+# % required: yes
+# % label: Threshold for 75 percentile of slope for potential trees
 # % answer: 70
 # % guisection: Parameters
 # %end
@@ -142,23 +142,23 @@
 # %option
 # % key: area_threshold
 # % type: double
-# % required: no
-# % label: Define area size threshold for potential trees
+# % required: yes
+# % label: Area size threshold for potential trees
 # % answer: 5
 # % guisection: Parameters
 # %end
 
 # %option G_OPT_R_OUTPUT
 # % key: trees_raster
-# % required: yes
-# % label: Name of output raster with single trees
+# % label: Name for output raster with single trees
+# % answer: tree_objects
 # % guisection: Output
 # %end
 
 # %option G_OPT_V_OUTPUT
 # % key: trees_vector
-# % required: yes
-# % label: Name of output vector with single trees
+# % label: Name for output vector with single trees
+# % answer: tree_objects
 # % guisection: Output
 # %end
 

--- a/grass-gis-addons/m.analyse.trees/v.trees.cd/v.trees.cd.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.cd/v.trees.cd.py
@@ -29,17 +29,13 @@
 # %option G_OPT_V_INPUT
 # %label: Name of the input vector layer of one timestamp/year
 # % guisection: Input
-# TODO: decide
-# % answer: treecrowns_2020
-# # % answer: tree_objects
+# % answer: tree_objects
 # %end
 
 # %option G_OPT_V_INPUT
 # % key: reference
 # % label: Name of the reference vector layer of another timestamp/year, to compare
-# TODO: decide
-# % answer: treecrowns_2022
-# # % answer: reference_trees
+# % answer: reference_trees
 # % guisection: Input
 # %end
 
@@ -74,10 +70,8 @@
 # %end
 
 # %option G_OPT_V_OUTPUT
-# % label: Basename of output vector maps
-# TODO: decide
-# % answer: cd_2020_2022
-# # % answer: trees_difference
+# % label: Basename for output vector maps
+# % answer: trees_difference
 # % guisection: Output
 # %end
 
@@ -92,7 +86,7 @@
 # % type: integer
 # % required: yes
 # % multiple: no
-# % label: Define edge length of grid tiles for parallel processing
+# % label: Edge length of grid tiles for parallel processing
 # % answer: 1000
 # % guisection: Parallel processing
 # %end

--- a/grass-gis-addons/m.analyse.trees/v.trees.cd/v.trees.cd.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.cd/v.trees.cd.py
@@ -27,21 +27,26 @@
 # %end
 
 # %option G_OPT_V_INPUT
-# % key: inp_t1
 # %label: Name of the input vector layer of one timestamp/year
 # % guisection: Input
+# TODO: decide
+# % answer: treecrowns_2020
+# # % answer: tree_objects
 # %end
 
 # %option G_OPT_V_INPUT
-# % key: inp_t2
-# % label: Name of the input vector layer of another timestamp/year, to compare
+# % key: reference
+# % label: Name of the reference vector layer of another timestamp/year, to compare
+# TODO: decide
+# % answer: treecrowns_2022
+# # % answer: reference_trees
 # % guisection: Input
 # %end
 
 # %option
-# % key: vec_congr_thr
+# % key: congr_thresh
 # % type: integer
-# % required: no
+# % required: yes
 # % multiple: no
 # % label: Threshold for overlap (in percentage) above which trees are considered to be congruent
 # % answer: 90
@@ -49,9 +54,9 @@
 # %end
 
 # %option
-# % key: vec_diff_min_size
+# % key: diff_min_size
 # % type: double
-# % required: no
+# % required: yes
 # % multiple: no
 # % label: Minimum size of identified change areas in sqm
 # % answer: 0.25
@@ -59,9 +64,9 @@
 # %end
 
 # %option
-# % key: vec_diff_max_fd
+# % key: diff_max_fd
 # % type: double
-# % required: no
+# % required: yes
 # % multiple: no
 # % label: Maximum value of fractal dimension of identified change areas (see v.to.db)
 # % answer: 2.5
@@ -70,6 +75,9 @@
 
 # %option G_OPT_V_OUTPUT
 # % label: Basename of output vector maps
+# TODO: decide
+# % answer: cd_2020_2022
+# # % answer: trees_difference
 # % guisection: Output
 # %end
 
@@ -256,12 +264,12 @@ def main():
 
     pid = os.getpid()
 
-    vec_inp_t1 = options["inp_t1"]
-    vec_inp_t2 = options["inp_t2"]
+    vec_inp_t1 = options["input"]
+    vec_inp_t2 = options["reference"]
     cd_output = options["output"]
-    vec_congr_thr = options["vec_congr_thr"]
-    vec_diff_min_size = options["vec_diff_min_size"]
-    vec_diff_max_fd = options["vec_diff_max_fd"]
+    vec_congr_thr = options["congr_thresh"]
+    vec_diff_min_size = options["diff_min_size"]
+    vec_diff_max_fd = options["diff_max_fd"]
     nprocs = int(options["nprocs"])
     tile_size = options["tile_size"]
 

--- a/grass-gis-addons/m.analyse.trees/v.trees.param.worker/v.trees.param.worker.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.param.worker/v.trees.param.worker.py
@@ -714,7 +714,11 @@ def main():
         treeheight(list_attr, treecrowns, ndsm)
     if not treeparamset or "area" in treeparamset:
         crownarea(list_attr, treecrowns)
-    if not treeparamset or "diameter" in treeparamset or "volume" in treeparamset:
+    if (
+        not treeparamset
+        or "diameter" in treeparamset
+        or "volume" in treeparamset
+    ):
         col_diameter = crowndiameter(list_attr, treecrowns)
     if not treeparamset or "ndvi" in treeparamset:
         ndvi_singletree(list_attr, treecrowns, ndvi)

--- a/grass-gis-addons/m.analyse.trees/v.trees.param.worker/v.trees.param.worker.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.param.worker/v.trees.param.worker.py
@@ -28,59 +28,6 @@
 # % keyword: worker
 # %end
 
-# %option G_OPT_V_INPUT
-# % key: treecrowns
-# % description: Subset vector map of tree crowns
-# % required: yes
-# %end
-
-# %option G_OPT_V_INPUT
-# % key: treecrowns_complete
-# % description: Complete vector map of tree crowns
-# % required: yes
-# %end
-
-# %option G_OPT_R_INPUT
-# % key: ndom
-# % description: Raster map of nDOM
-# % required: no
-# %end
-
-# %option G_OPT_R_INPUT
-# % key: ndvi
-# % description: Raster map of NDVI
-# % required: no
-# %end
-
-# %option G_OPT_V_INPUT
-# % key: buildings
-# % description: Vector map of buildings
-# % required: no
-# %end
-
-# %option
-# % key: distance_building
-# % type: integer
-# % description: Range in which neighbouring buildings are searched for
-# % required: no
-# %end
-
-# %option
-# % key: distance_tree
-# % type: integer
-# % description: Range in which neighbouring trees are searched for
-# % required: no
-# % answer: 500
-# %end
-
-# %option
-# % key: treeparamset
-# % description: Set of tree parameters, which should be calculated
-# % required: no
-# % multiple: yes
-# % options: position,hoehe,dm,volumen,flaeche,ndvi,dist_geb,dist_baum
-# %end
-
 # %option
 # % key: new_mapset
 # % type: string
@@ -88,6 +35,56 @@
 # % multiple: no
 # % key_desc: name
 # % description: Name for new mapset
+# %end
+
+# %option G_OPT_V_INPUT
+# % key: treecrowns
+# % description: Subset vector map of tree crowns
+# %end
+
+# %option G_OPT_V_INPUT
+# % key: treecrowns_complete
+# % description: Complete vector map of tree crowns
+# %end
+
+# %option G_OPT_R_INPUT
+# % key: ndsm
+# % required: no
+# % description: Name of the nDSM raster
+# %end
+
+# %option G_OPT_R_INPUT
+# % key: ndvi
+# % required: no
+# % description: Name of the NDVI raster
+# %end
+
+# %option G_OPT_V_INPUT
+# % key: buildings
+# % required: no
+# % description: Name of the buildings vector map
+# %end
+
+# %option
+# % key: distance_building
+# % type: integer
+# % required: no
+# % description: Range in which is searched for neighbouring buildings
+# %end
+
+# %option
+# % key: distance_tree
+# % type: integer
+# % required: no
+# % description: Range in which is searched for neighbouring trees
+# %end
+
+# %option
+# % key: treeparamset
+# % required:yes
+# % multiple: yes
+# % description: Set of tree parameters, which should be calculated
+# % options: position,height,diameter,volume,area,ndvi,dist_building,dist_tree
 # %end
 
 # %option G_OPT_MEMORYMB
@@ -117,9 +114,9 @@ def cleanup():
         grass.try_remove(treetrunk_SQL_temp)
 
 
-def treeheight(list_attr, treecrowns, ndom):
+def treeheight(list_attr, treecrowns, ndsm):
     # tree height:
-    # The tree height can be determined via the nDOM
+    # The tree height can be determined via the nDSM
     # as the highest point of the crown area
     grass.message(_("Calculating tree height..."))
     col_height = "height"
@@ -156,7 +153,7 @@ def treeheight(list_attr, treecrowns, ndom):
         "v.rast.stats",
         map=treecrowns,
         type="area",
-        raster=ndom,
+        raster=ndsm,
         column_prefix=col_height,
         method="maximum,percentile",
         percentile=95,
@@ -636,7 +633,7 @@ def main():
 
     treecrowns = options["treecrowns"]
     treecrowns_complete = options["treecrowns_complete"]
-    ndom = options["ndom"]
+    ndsm = options["ndsm"]
     ndvi = options["ndvi"]
     buildings = options["buildings"]
     distance_building = options["distance_building"]
@@ -667,13 +664,13 @@ def main():
     # switch to another mapset for parallel postprocessing
     gisrc, newgisrc, old_mapset = switch_to_new_mapset(new_mapset)
     # create fully qualified names
-    if ndom:
-        if "@" not in ndom:
+    if ndsm:
+        if "@" not in ndsm:
             if not grass.find_file(
-                name=f"{ndom}@{old_mapset}", element="cell"
+                name=f"{ndsm}@{old_mapset}", element="cell"
             )["file"]:
-                grass.fatal(_("Input map %s not available!") % ndom)
-            ndom = f"{ndom}@{old_mapset}"
+                grass.fatal(_("Input map %s not available!") % ndsm)
+            ndsm = f"{ndsm}@{old_mapset}"
     if ndvi:
         if "@" not in ndvi:
             if not grass.find_file(
@@ -713,21 +710,21 @@ def main():
     ]
 
     # Calculate various tree parameters
-    if not treeparamset or "hoehe" in treeparamset:
-        treeheight(list_attr, treecrowns, ndom)
-    if not treeparamset or "flaeche" in treeparamset:
+    if not treeparamset or "height" in treeparamset:
+        treeheight(list_attr, treecrowns, ndsm)
+    if not treeparamset or "area" in treeparamset:
         crownarea(list_attr, treecrowns)
-    if not treeparamset or "dm" in treeparamset or "volumen" in treeparamset:
+    if not treeparamset or "diameter" in treeparamset or "volume" in treeparamset:
         col_diameter = crowndiameter(list_attr, treecrowns)
     if not treeparamset or "ndvi" in treeparamset:
         ndvi_singletree(list_attr, treecrowns, ndvi)
-    if not treeparamset or "volumen" in treeparamset:
+    if not treeparamset or "volume" in treeparamset:
         crownvolume(list_attr, treecrowns, col_diameter)
     if not treeparamset or "position" in treeparamset:
         treetrunk(list_attr, treecrowns)
-    if not treeparamset or "dist_geb" in treeparamset:
+    if not treeparamset or "dist_building" in treeparamset:
         dist_to_building(list_attr, treecrowns, buildings, distance_building)
-    if not treeparamset or "dist_baum" in treeparamset:
+    if not treeparamset or "dist_tree" in treeparamset:
         dist_to_tree(
             list_attr, treecrowns, treecrowns_complete, pid, distance_tree
         )

--- a/grass-gis-addons/m.analyse.trees/v.trees.param/v.trees.param.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.param/v.trees.param.py
@@ -214,6 +214,7 @@ def main():
     use_memory = round(memory / nprocs)
     subset_ind = 0
     try:
+        grass.message(_("Creating treecrown subsets ..."))
         for num in range(nprocs):
             # use pid to create a unique mapset and vector subset name
             sid = f"{num}_{pid}"
@@ -237,6 +238,11 @@ def main():
                 quiet=True,
             )
             # Module
+            grass.message(
+                _(
+                    f"Starting calculation of tree parameters: {treeparamset}..."
+                )
+            )
             new_mapset = "tmp_mapset_treeparam_" + sid
             mapset_names.append(new_mapset)
             param = {

--- a/grass-gis-addons/m.analyse.trees/v.trees.param/v.trees.param.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.param/v.trees.param.py
@@ -30,56 +30,60 @@
 
 # %option G_OPT_V_INPUT
 # % key: treecrowns
-# % label: Vector map of tree crowns
-# % required: yes
+# % label: Name of the tree crowns vector map
+# % answer: tree_objects
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
-# % key: ndom
-# % label: Raster map of nDSM
+# % key: ndsm
 # % required: no
+# % label: Name of the nDSM raster
+# % answer: ndsm
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndvi
-# % label: Raster map of NDVI
 # % required: no
+# % label: Name of the NDVI raster
+# % answer: top_ndvi_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_V_INPUT
 # % key: buildings
-# % label: Vector map of buildings
 # % required: no
+# % label: Name of the buildings vector map
+# % answer: reference_buildings
 # % guisection: Input
 # %end
 
 # %option
 # % key: distance_building
 # % type: integer
-# % label: Range in which neighbouring buildings are searched for
 # % required: no
+# % label: Range in which is searched for neighbouring buildings
+# % answer: 500
 # % guisection: Parameters
 # %end
 
 # %option
 # % key: distance_tree
 # % type: integer
-# % label: Range in which neighbouring trees are searched for
 # % required: no
+# % label: Range in which is searched for neighbouring trees
 # % answer: 500
 # % guisection: Parameters
 # %end
 
 # %option
 # % key: treeparamset
-# % label: Set of tree parameters, which should be calculated
-# % required: no
+# % required: yes
 # % multiple: yes
-# % options: position,hoehe,dm,volumen,flaeche,ndvi,dist_geb,dist_baum
-# % answer: position,hoehe,dm,volumen,flaeche,ndvi,dist_geb,dist_baum
+# % label: Set of tree parameters, which should be calculated
+# % options: position,height,diameter,volume,area,ndvi,dist_building,dist_tree
+# % answer: position,height,diameter,volume,area,ndvi,dist_building,dist_tree
 # % guisection: Parameters
 # %end
 
@@ -136,7 +140,7 @@ def main():
     pid = os.getpid()
 
     treecrowns = options["treecrowns"].split("@")[0]
-    ndom = options["ndom"]
+    ndsm = options["ndsm"]
     ndvi = options["ndvi"]
     buildings = options["buildings"]
     distance_building = options["distance_building"]
@@ -144,12 +148,12 @@ def main():
     memory = int(options["memory"])
     nprocs = int(options["nprocs"])
     treeparamset = options["treeparamset"].split(",")
-    if "dist_geb" in treeparamset and not buildings:
+    if "dist_building" in treeparamset and not buildings:
         grass.fatal(_("Need buildings as input."))
     if "ndvi" in treeparamset and not ndvi:
         grass.fatal(_("Need NDVI as input."))
-    if "hoehe" in treeparamset and not ndom:
-        grass.fatal(_("Need nDOM as input."))
+    if "height" in treeparamset and not ndsm:
+        grass.fatal(_("Need nDSM as input."))
 
     path = get_lib_path(modname="m.analyse.trees", libname="analyse_trees_lib")
     if path is None:
@@ -240,8 +244,8 @@ def main():
                 "treecrowns_complete": treecrowns,
                 "treeparamset": treeparamset,
             }
-            if ndom:
-                param["ndom"] = ndom
+            if ndsm:
+                param["ndsm"] = ndsm
             if ndvi:
                 param["ndvi"] = ndvi
             if buildings:

--- a/grass-gis-addons/m.analyse.trees/v.trees.species/v.trees.species.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.species/v.trees.species.py
@@ -26,50 +26,50 @@
 
 # %option G_OPT_R_INPUT
 # % key: red_raster
-# % required: yes
-# % label: Name of the red band
+# % label: Name of the red raster
+# % answer: top_red_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: green_raster
-# % required: yes
-# % label: Name of the green band
+# % label: Name of the green raster
+# % answer: top_green_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: blue_raster
-# % required: yes
-# % label: Name of the blue band
+# % label: Name of the blue raster
+# % answer: top_blue_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: nir_raster
-# % required: yes
-# % label: Name of the NIR band
+# % label: Name of the NIR raster
+# % answer: top_nir_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndvi
-# % required: yes
 # % label: Name of the NDVI raster
+# % answer: top_ndvi_02
 # % guisection: Input
 # %end
 
 # %option G_OPT_R_INPUT
 # % key: ndsm
-# % required: yes
 # % label: Name of the nDSM raster
+# % answer: ndsm
 # % guisection: Input
 # %end
 
 # %option G_OPT_V_INPUT
 # % key: treecrowns
 # % label: Vector map of tree crowns
-# % required: yes
+# % answer: tree_objects
 # % guisection: Input
 # %end
 

--- a/grass-gis-addons/m.analyse.trees/v.trees.species/v.trees.species.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.species/v.trees.species.py
@@ -53,7 +53,7 @@
 # %end
 
 # %option G_OPT_R_INPUT
-# % key: ndvi
+# % key: ndvi_raster
 # % label: Name of the NDVI raster
 # % answer: top_ndvi_02
 # % guisection: Input
@@ -74,7 +74,7 @@
 # %end
 
 # %option G_OPT_R_INPUT
-# % key: ndwi
+# % key: ndwi_raster
 # % required: no
 # % label: Name of the NDWI raster
 # % guisection: Optional input
@@ -216,8 +216,8 @@ def main():
     blue = options["blue_raster"]
     red = options["red_raster"]
     nir = options["nir_raster"]
-    ndvi = options["ndvi"]
-    ndwi = options["ndwi"]
+    ndvi = options["ndvi_raster"]
+    ndwi = options["ndwi_raster"]
     ndsm = options["ndsm"]
     nprocs = set_nprocs(int(options["nprocs"]))
     memory = test_memory(options["memory"])


### PR DESCRIPTION
MR unifys parameters for the tree addons (m.analyse.trees), especially it:

- labels parameters as required
- uses parser standard options
- renames parameters, options etc. to English
- adapts/unifys label text
- reorders some parameters
- sets default values for required parameters
  - if output is previously set to default, then this value is set as input in next addon -> note: if output is named differently by the user, then default input must also be adjusted for the next module

