### PR TITLE
reduce default param to exclude dist_tree and dist_building

### DIFF
--- a/grass-gis-addons/m.analyse.trees/v.trees.param/v.trees.param.py
+++ b/grass-gis-addons/m.analyse.trees/v.trees.param/v.trees.param.py
@@ -62,7 +62,7 @@
 # % multiple: yes
 # % label: Set of tree parameters, which should be calculated
 # % options: position,height,diameter,volume,area,ndvi,dist_building,dist_tree
-# % answer: position,height,diameter,volume,area,ndvi,dist_building,dist_tree
+# % answer: position,height,diameter,volume,area,ndvi
 # % guisection: Parameters
 # %end
 


### PR DESCRIPTION
Reduced the default tree parameters to exclude the time consuming distance calculations.