### PR TITLE
scikit-learn fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV GRASS_ADDON_BASE=/usr/local/grass84
 
 # install external dependencies
 # do not use scikit-learn >=1.6 because it introduced breaking changes incompatible with r.learn.ml2 
-RUN pip3 install py7zr tqdm requests psutil scikit-learn==1.5.2 pyproj pandas
+RUN pip3 install py7zr tqdm requests psutil "scikit-learn==1.5.2" pyproj pandas
 
 # install official addons
 RUN grass --tmp-location EPSG:4326 --exec g.extension r.mapcalc.tiled -s

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ ENV PROJ_NETWORK=ON
 ENV GRASS_ADDON_BASE=/usr/local/grass84
 
 # install external dependencies
-RUN pip3 install py7zr tqdm requests psutil scikit-learn pyproj pandas
+# do not use scikit-learn >=1.6 because it introduced breaking changes incompatible with r.learn.ml2 
+RUN pip3 install py7zr tqdm requests psutil scikit-learn==1.5.2 pyproj pandas
 
 # install official addons
 RUN grass --tmp-location EPSG:4326 --exec g.extension r.mapcalc.tiled -s


### PR DESCRIPTION
Avoid scikit-learn versions >= 1.6 because breaking changes were introduced with 1.6 causing [r.learn.ml2](https://github.com/OSGeo/grass-addons/tree/grass8/src/raster/r.learn.ml2) to fail.

Fixes #92